### PR TITLE
A TemplateDataModel is now available for step property expressions, f…

### DIFF
--- a/_examples/experimentals/templates/bitrise.yml
+++ b/_examples/experimentals/templates/bitrise.yml
@@ -5,10 +5,17 @@ workflows:
     envs: []
     steps:
     - script:
-        title: Hello Bitrise!
+        title: Run-If expression
         run_if: |
           {{getenv "CI" | eq "true"}}
         inputs:
         - content: |-
             #!/bin/bash
-            echo "Welcome to Bitrise!"
+            echo "RunIf expression was true"
+    - script:
+        title: Run-If expression
+        run_if: .IsCI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "RunIf expression was true"

--- a/_examples/experimentals/templates/bitrise.yml
+++ b/_examples/experimentals/templates/bitrise.yml
@@ -2,19 +2,75 @@ format_version: 0.9.5
 default_step_lib_source: https://bitbucket.org/bitrise-team/bitrise-new-steps-spec
 workflows:
   primary:
-    envs: []
     steps:
+    #
+    # Get and compare envs
     - script:
         title: Run-If expression
         run_if: |
-          {{getenv "CI" | eq "true"}}
+          {{getenv "TEST_KEY" | eq "test value"}}
         inputs:
         - content: |-
             #!/bin/bash
             echo "RunIf expression was true"
+    #
+    # Or if that's all you want to do just use the enveq function
+    - script:
+        title: Run-If expression
+        run_if: '{{enveq "TEST_KEY" "test value"}}'
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "RunIf expression was true"
+    #
+    # Use the available expression data properties
+    #  like IsCI or IsBuildFailed directly
+    - script:
+        title: Run-If expression
+        run_if: "{{.IsCI}}"
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "RunIf expression was true"
+    #
+    # You don't have to wrap the expression in {{...}} if it's a simple
+    #  oneliner
+    - script:
+        title: Run-If expression
+        run_if: $.IsCI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "RunIf expression was true"
+    #
+    # You can even remove the $ sign, it's optional in a simple
+    #  expression like this
     - script:
         title: Run-If expression
         run_if: .IsCI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "RunIf expression was true"
+    #
+    # If-Else condition
+    - script:
+        title: Run-If expression
+        run_if: |
+          {{if .IsCI}}
+          true
+          {{else}}
+          false
+          {{end}}
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "RunIf expression was true"
+    #
+    # Multi condition
+    - script:
+        title: Run-If expression
+        run_if: "{{.IsCI | and (not .IsBuildFailed)}}"
         inputs:
         - content: |-
             #!/bin/bash

--- a/bitrise/template_util.go
+++ b/bitrise/template_util.go
@@ -2,7 +2,9 @@ package bitrise
 
 import (
 	"bytes"
+	"errors"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/bitrise-io/bitrise-cli/models/models_1_0_0"
@@ -10,21 +12,47 @@ import (
 )
 
 var (
-	funcMap = template.FuncMap{
-		"getenv": func(key string) string { return os.Getenv(key) },
+	templateFuncMap = template.FuncMap{
+		"getenv": func(key string) string {
+			return os.Getenv(key)
+		},
 	}
 )
 
+// TemplateDataModel ...
+type TemplateDataModel struct {
+	BuildResults  models.StepRunResultsModel
+	IsBuildFailed bool
+	IsCI          bool
+}
+
+func createTemplateDataModel(buildResults models.StepRunResultsModel, isCI bool) TemplateDataModel {
+	return TemplateDataModel{
+		BuildResults:  buildResults,
+		IsBuildFailed: buildResults.IsBuildFailed(),
+		IsCI:          isCI,
+	}
+}
+
 // EvaluateStepTemplateToBool ...
-func EvaluateStepTemplateToBool(expStr string, buildResults models.StepRunResultsModel) (bool, error) {
-	tmpl := template.New("EvaluateStepTemplateToBool").Funcs(funcMap)
+func EvaluateStepTemplateToBool(expStr string, buildResults models.StepRunResultsModel, isCI bool) (bool, error) {
+	if expStr == "" {
+		return false, errors.New("EvaluateStepTemplateToBool: Invalid, empty input: expStr")
+	}
+
+	if !strings.Contains(expStr, "{{") {
+		expStr = "{{" + expStr + "}}"
+	}
+
+	tmpl := template.New("EvaluateStepTemplateToBool").Funcs(templateFuncMap)
 	tmpl, err := tmpl.Parse(expStr)
 	if err != nil {
 		return false, err
 	}
 
+	templateData := createTemplateDataModel(buildResults, isCI)
 	var resBuffer bytes.Buffer
-	if err := tmpl.Execute(&resBuffer, buildResults); err != nil {
+	if err := tmpl.Execute(&resBuffer, templateData); err != nil {
 		return false, err
 	}
 	resString := resBuffer.String()

--- a/bitrise/template_util.go
+++ b/bitrise/template_util.go
@@ -16,6 +16,9 @@ var (
 		"getenv": func(key string) string {
 			return os.Getenv(key)
 		},
+		"enveq": func(key, expectedValue string) bool {
+			return (os.Getenv(key) == expectedValue)
+		},
 	}
 )
 

--- a/bitrise/template_utils_test.go
+++ b/bitrise/template_utils_test.go
@@ -118,9 +118,23 @@ func TestRegisteredFlags(t *testing.T) {
 		t.Fatal("Invalid result")
 	}
 
+	propTempCont = `$.IsCI`
+	isCI = true
+	t.Log("IsCI=true; short with $; propTempCont: ", propTempCont)
+	if err := os.Setenv("CI", "true"); err != nil {
+		t.Fatal("Failed to set test env!")
+	}
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, isCI)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isYes {
+		t.Fatal("Invalid result")
+	}
+
 	propTempCont = `.IsCI`
 	isCI = true
-	t.Log("IsCI=true; short; propTempCont: ", propTempCont)
+	t.Log("IsCI=true; short, no $; propTempCont: ", propTempCont)
 	if err := os.Setenv("CI", "true"); err != nil {
 		t.Fatal("Failed to set test env!")
 	}

--- a/bitrise/template_utils_test.go
+++ b/bitrise/template_utils_test.go
@@ -12,7 +12,7 @@ func TestEvaluateStepTemplateToBool(t *testing.T) {
 
 	propTempCont := `{{eq 1 1}}`
 	t.Log("Simple true")
-	isYes, err := EvaluateStepTemplateToBool(propTempCont, buildRes)
+	isYes, err := EvaluateStepTemplateToBool(propTempCont, buildRes, false)
 	if err != nil {
 		t.Fatal("Unexpected error:", err)
 	}
@@ -22,7 +22,7 @@ func TestEvaluateStepTemplateToBool(t *testing.T) {
 
 	propTempCont = `{{eq 1 2}}`
 	t.Log("Simple false")
-	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes)
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, false)
 	if err != nil {
 		t.Fatal("Unexpected error:", err)
 	}
@@ -35,15 +35,79 @@ func TestRegisteredFunctions(t *testing.T) {
 	buildRes := models.StepRunResultsModel{}
 
 	propTempCont := `{{getenv "CI" | eq "true"}}`
-	t.Log("getenv")
+	t.Log("propTempCont: ", propTempCont)
 	if err := os.Setenv("CI", "true"); err != nil {
 		t.Fatal("Failed to set test env!")
 	}
-	isYes, err := EvaluateStepTemplateToBool(propTempCont, buildRes)
+	isYes, err := EvaluateStepTemplateToBool(propTempCont, buildRes, false)
 	if err != nil {
 		t.Fatal("Unexpected error:", err)
 	}
 	if !isYes {
 		t.Fatal("Invalid result")
+	}
+
+	propTempCont = `{{.IsCI}}`
+	isCI := true
+	t.Log("IsCI=true; propTempCont: ", propTempCont)
+	if err := os.Setenv("CI", "true"); err != nil {
+		t.Fatal("Failed to set test env!")
+	}
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, isCI)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isYes {
+		t.Fatal("Invalid result")
+	}
+
+	propTempCont = `{{.IsCI}}`
+	isCI = false
+	t.Log("IsCI=fase; propTempCont: ", propTempCont)
+	if err := os.Setenv("CI", "true"); err != nil {
+		t.Fatal("Failed to set test env!")
+	}
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, isCI)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isYes {
+		t.Fatal("Invalid result")
+	}
+
+	propTempCont = `.IsCI`
+	isCI = true
+	t.Log("IsCI=true; short; propTempCont: ", propTempCont)
+	if err := os.Setenv("CI", "true"); err != nil {
+		t.Fatal("Failed to set test env!")
+	}
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, isCI)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isYes {
+		t.Fatal("Invalid result")
+	}
+
+	propTempCont = `{{not .IsCI}}`
+	isCI = true
+	t.Log("IsCI=true; NOT; propTempCont: ", propTempCont)
+	if err := os.Setenv("CI", "true"); err != nil {
+		t.Fatal("Failed to set test env!")
+	}
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, isCI)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isYes {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("Invalid - empty expression")
+	isYes, err = EvaluateStepTemplateToBool("", buildRes, true)
+	if err == nil {
+		t.Fatal("Should return an error!")
+	} else {
+		t.Log("[expected] Error:", err)
 	}
 }

--- a/bitrise/template_utils_test.go
+++ b/bitrise/template_utils_test.go
@@ -34,9 +34,9 @@ func TestEvaluateStepTemplateToBool(t *testing.T) {
 func TestRegisteredFunctions(t *testing.T) {
 	buildRes := models.StepRunResultsModel{}
 
-	propTempCont := `{{getenv "CI" | eq "true"}}`
-	t.Log("propTempCont: ", propTempCont)
-	if err := os.Setenv("CI", "true"); err != nil {
+	propTempCont := `{{getenv "TEST_KEY" | eq "Test value"}}`
+	t.Log("getenv - YES - propTempCont: ", propTempCont)
+	if err := os.Setenv("TEST_KEY", "Test value"); err != nil {
 		t.Fatal("Failed to set test env!")
 	}
 	isYes, err := EvaluateStepTemplateToBool(propTempCont, buildRes, false)
@@ -47,13 +47,56 @@ func TestRegisteredFunctions(t *testing.T) {
 		t.Fatal("Invalid result")
 	}
 
-	propTempCont = `{{.IsCI}}`
+	propTempCont = `{{getenv "TEST_KEY" | eq "A different value"}}`
+	t.Log("getenv - NO - propTempCont: ", propTempCont)
+	if err := os.Setenv("TEST_KEY", "Test value"); err != nil {
+		t.Fatal("Failed to set test env!")
+	}
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, false)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isYes {
+		t.Fatal("Invalid result")
+	}
+
+	propTempCont = `{{enveq "TEST_KEY" "enveq value"}}`
+	t.Log("enveq - YES - propTempCont: ", propTempCont)
+	if err := os.Setenv("TEST_KEY", "enveq value"); err != nil {
+		t.Fatal("Failed to set test env!")
+	}
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, false)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isYes {
+		t.Fatal("Invalid result")
+	}
+
+	propTempCont = `{{enveq "TEST_KEY" "different enveq value"}}`
+	t.Log("enveq - NO - propTempCont: ", propTempCont)
+	if err := os.Setenv("TEST_KEY", "enveq value"); err != nil {
+		t.Fatal("Failed to set test env!")
+	}
+	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, false)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isYes {
+		t.Fatal("Invalid result")
+	}
+}
+
+func TestRegisteredFlags(t *testing.T) {
+	buildRes := models.StepRunResultsModel{}
+
+	propTempCont := `{{.IsCI}}`
 	isCI := true
 	t.Log("IsCI=true; propTempCont: ", propTempCont)
 	if err := os.Setenv("CI", "true"); err != nil {
 		t.Fatal("Failed to set test env!")
 	}
-	isYes, err = EvaluateStepTemplateToBool(propTempCont, buildRes, isCI)
+	isYes, err := EvaluateStepTemplateToBool(propTempCont, buildRes, isCI)
 	if err != nil {
 		t.Fatal("Unexpected error:", err)
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -9,6 +9,11 @@ import (
 	"github.com/codegangsta/cli"
 )
 
+var (
+	// IsCIMode ...
+	IsCIMode = false
+)
+
 func before(c *cli.Context) error {
 	// Log level
 	level, err := log.ParseLevel(c.String(LogLevelKey))
@@ -20,6 +25,16 @@ func before(c *cli.Context) error {
 		log.Fatal("Failed to set log level env:", err)
 	}
 	log.SetLevel(level)
+
+	// CI
+	//  if CI mode indicated make sure we set the related env
+	//  so all other tools we use will also get it
+	if c.IsSet(CIKey) {
+		if err := os.Setenv("CI", "true"); err != nil {
+			return err
+		}
+		IsCIMode = true
+	}
 
 	return nil
 }

--- a/cli/doRun.go
+++ b/cli/doRun.go
@@ -244,7 +244,7 @@ func activateAndRunSteps(workflow models.WorkflowModel, defaultStepLibSource str
 		fmt.Println()
 
 		if mergedStep.RunIf != nil && *mergedStep.RunIf != "" {
-			isRun, err := bitrise.EvaluateStepTemplateToBool(*mergedStep.RunIf, stepRunResults)
+			isRun, err := bitrise.EvaluateStepTemplateToBool(*mergedStep.RunIf, stepRunResults, IsCIMode)
 			if err != nil {
 				registerFailedStep(mergedStep, err)
 				continue


### PR DESCRIPTION
…or easier "IsCI" detection.

You can also just write ".IsCI", instead of the longer "{{.IsCI}}"
the "CI=true" env is set at the start to force every tool to work in CI mode (even if the CI mode was just a command line param)